### PR TITLE
.github: fix action fail, dlopen(): error loading libfuse.so.2

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install -y python3 python3-dev nodejs git gcc
+          sudo apt install -y libfuse2
           sudo pip install -U pip setuptools
           sudo pip install neovim
 


### PR DESCRIPTION
.github: fix action fail, dlopen(): error loading libfuse.so.2

Action fails, reference:
1. https://github.com/xaljer/nvide/actions/runs/7993238523/job/21828578922
```
=========start to install neovim and plug.vim========
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

  0 17.3M    0 95103    0     0   460k      0  0:00:38 --:--:--  0:00:38  460k
100 17.3M  100 17.3M    0     0  55.9M      0 --:--:-- --:--:-- --:--:--  159M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 83127  100 83127    0     0   812k      0 --:--:-- --:--:-- --:--:--  819k
=========start to install plugins=========
dlopen(): error loading libfuse.so.2

AppImages require FUSE to run.
You might still be able to extract the contents of this AppImage
if you run it with the --appimage-extract option.
See https://github.com/AppImage/AppImageKit/wiki/FUSE
for more information
Error: Process completed with exit code 1.
```
2. https://juejin.cn/post/7092596416245137445

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>